### PR TITLE
fix(reward): use only y positions for enemy presence to prevent right…

### DIFF
--- a/env.py
+++ b/env.py
@@ -259,8 +259,8 @@ class ClashRoyaleEnv:
 
         # Sum all enemy positions (not just the first)
         enemy_positions = state[1 + 2 * MAX_ALLIES:]  # All enemy x1, y1, x2, y2, ...
-        enemy_presence = sum(enemy_positions)
-
+        # enemy_presence = sum(enemy_positions)
+        enemy_presence = sum(enemy_positions[1::2]) # Only y coords so it does not bias left/right side
         reward = -enemy_presence
 
         # Elixir efficiency: reward for spending elixir if it reduces enemy presence


### PR DESCRIPTION
**Issue:**
In the `_compute_reward()` function, the calculation of `enemy_presence` currently sums up both the **x** and **y** coordinates of enemy troops:

```python
# Sum all enemy positions (not just the first)
enemy_positions = state[1 + 2 * MAX_ALLIES:]  # All enemy x1, y1, x2, y2, ...
enemy_presence = sum(enemy_positions)

reward = -enemy_presence
```

This introduces a bias because normalized **x** values are larger for troops on the right side of the arena than for those on the left, even though both can be equally dangerous. As a result, the bot is penalized more heavily for right-side enemies than for left-side enemies.

**Fix:**
Change the calculation to only consider the **y** coordinates (depth toward our side of the field), so the penalty reflects how close enemies are rather than whether they’re on the left or right:

```python
enemy_presence = sum(enemy_positions[1::2])
```

---

Do you want me to also phrase this as a **GitHub issue template** (with “Steps to Reproduce”, “Expected Behavior”, etc.) so you can drop it straight into your repo?
